### PR TITLE
Поменял http на https в репозитории primefaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <repository>
             <id>prime-repo</id>
             <name>PrimeFaces Maven Repository</name>
-            <url>http://repository.primefaces.org</url>
+            <url>https://repository.primefaces.org</url>
             <layout>default</layout>
         </repository>
     </repositories>


### PR DESCRIPTION
Т.к. maven больше не поддерживает http, сборка валится при попытке скачать артефакт. Поменял на https.